### PR TITLE
Command timeouts with restart support

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,6 +154,10 @@ mongoose.connect(connectionURL, {
 const mutils = require("./main/functions/mongoUtils");
 bot.mutils = mutils;
 
+const { TimeoutUtils } = require("./main/functions/timeoutUtils");
+const timeouts = new TimeoutUtils(bot);
+bot.timeouts = timeouts;
+
 // Global API
 const express = require('express');
 const app = express();

--- a/main/functions/timeoutUtils.js
+++ b/main/functions/timeoutUtils.js
@@ -1,0 +1,110 @@
+const Timeout = require("../models/timeouts");
+const moment = require('moment');
+
+class TimeoutUtils {
+    constructor(bot) {
+        /*
+        Check the database for any old timeouts which need to be rebooted
+        */
+        this.bot = bot;
+        this.activeTimeouts = 0;   
+
+        this.fetchAll()
+        .then(allTimeouts => { 
+            let removedTimeouts = 0;
+            allTimeouts.forEach(timeout => {
+                if (this.expired(timeout.expires)) {
+                    removedTimeouts++;
+                    this.removeSync(timeout.user, timeout.command);
+                } else {
+                    this.activeTimeouts++;
+                    let present = moment();
+                    setTimeout(() => {
+                        this.removeSync(timeout.user, timeout.command);
+                    }, (timeout.expires - present.unix()) * 1000)
+                }
+            })
+            bot.logger("success", `[-] Removed ${removedTimeouts} expired timeouts`);
+            bot.logger("success", `[+] Rebooted ${this.activeTimeouts} active timeouts`)
+        })
+        .catch(error => bot.logger("error", error))
+    }
+
+    //Fetch all timeouts (including expired if still in database)
+    fetchAll() {
+        return new Promise(async (resolve, reject) => {
+            try { resolve(await Timeout.find({}))
+            } catch (error) { reject(error) }
+        })
+    }
+    
+    //Adds a new timeout to the database
+    new(user, command) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                if (!user) { reject("Please specify a user ID.") }
+                let present = moment();
+                //Specify the expiry time for each of the commands here using momentjs manipulation syntax https://momentjs.com/docs/#/manipulating/
+                //Adding new commands is just adding a new case to this switch statement with a new expiry
+                switch (command) {
+                    case "daily":
+                        present.add(1, "d");
+                        break;  
+                    case "rob":
+                        present.add(2, "h");
+                        break;
+                    default: 
+                        reject(`Invalid command: ${command}`)
+                }
+                //Save new timeout
+                const timeout = new Timeout({ user, command, expires: present.unix() })
+                await timeout.save();
+
+                let newPresent = moment();
+                this.activeTimeouts++;
+
+                setTimeout(() => {
+                    this.removeSync(user, command);
+                }, (present.unix() - newPresent.unix()) * 1000)
+                resolve(timeout)
+
+            } catch (error) { reject(error) }
+        })
+    }
+
+    //Checks if a timeout expiry is expired
+    expired(expiry) {
+        const present = moment()
+        if (present.unix() > expiry) { return true }
+        else { return false }
+    }
+
+    //Remove a timeout from the database (returns undefined on success)
+    removeSync(user, command) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                await Timeout.findOneAndDelete({ user, command })
+                resolve();
+            } catch (error) { reject(error) }
+        })
+    }
+
+    //Checks if a timeout exists and if it does, returns how long is left on it
+    check(user, command) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                let timeout = await Timeout.findOne({ user, command });
+                if (timeout) {
+
+                    let present = moment();
+                    let untilExpiry = moment.duration((timeout.expires - present.unix()) * 1000);
+                    resolve(untilExpiry.humanize(true))
+
+                } else { resolve(false) }
+            } catch (error) { reject(error) }
+        })
+    }
+
+}
+
+module.exports = { TimeoutUtils }

--- a/main/models/timeouts.js
+++ b/main/models/timeouts.js
@@ -1,0 +1,21 @@
+const mongoose = require('mongoose');
+
+const timeoutsSchema = new mongoose.Schema({
+
+    user: {             //ID of user
+        type: String,
+        required: [true, "A user ID is required."]
+    },
+    command: {          //String of command (must be a valid command in validCommands)
+        type: String,
+        required: [true, "A command type is required."],
+    },
+    expires: {          //Date for when the timeout expires
+        type: Number,
+        required: [true, "A timeout expiration date is required."]
+    }
+
+}, { timestamps: true });
+
+const Timeouts = mongoose.model("Timeouts", timeoutsSchema);
+module.exports = Timeouts;


### PR DESCRIPTION
Uses MongoDB to store user command timeouts.
Reloads the timeouts on bot startup.
Currently tested:
- Creates working timeouts that expire
- Timeouts expire after reboot
- Check works
- Expired timeouts are removed if they expire whilst the bot is down